### PR TITLE
API errors handled successfully within search view

### DIFF
--- a/CineSightApp/CineSightApp/MovieService.swift
+++ b/CineSightApp/CineSightApp/MovieService.swift
@@ -9,7 +9,7 @@ import Foundation
 
 class MovieService {
     func searchMovies(query: String, completion: @escaping (Result<[Movie], Error>) -> Void) {
-        let urlString = "https://api.themoviedb.org/3/search/movie?api_key=28e9425ecdb2044c235d4eec5419342e&query=\(query)"
+        let urlString = "https://api.themoviedb.org/3/search/movie?api_key=INVALID_API_KEY&query=\(query)"
         if let url = URL(string: urlString) {
             URLSession.shared.dataTask(with: url) { data, response, error in
                 DispatchQueue.main.async {

--- a/CineSightApp/CineSightApp/MovieViewModel.swift
+++ b/CineSightApp/CineSightApp/MovieViewModel.swift
@@ -10,12 +10,22 @@ import SwiftUI
 import Combine
 
 class MovieViewModel: ObservableObject {
+    @Published var apiError: Error?
     @Published var movies: [Movie] = []
     @Published var isLoading: Bool = false
     @Published var error: Error?
+    @Published var showErrorAlert: Bool = false
     @Published var searchText: String = "" {
         didSet {
             searchMovies()
+        }
+    }
+    
+    func handleAPIError() {
+        if self.error != nil {
+            self.showErrorAlert = true
+        } else {
+            self.showErrorAlert = false
         }
     }
     
@@ -29,6 +39,7 @@ class MovieViewModel: ObservableObject {
                     self.isLoading = false
                 case .failure(let error):
                     self.error = error
+                    self.handleAPIError()
                     self.isLoading = false
                 }
             }

--- a/CineSightApp/CineSightApp/View/SearchView.swift
+++ b/CineSightApp/CineSightApp/View/SearchView.swift
@@ -78,21 +78,29 @@ struct SearchView: View {
     @ObservedObject var viewModel = MovieViewModel()
     
     var body: some View {
-        VStack {
+        VStack(alignment: .leading, spacing: 10) {
             HeaderView(title: "SEARCH MOVIES")
             SearchBar(text: $viewModel.searchText)
             
-            if viewModel.isLoading {
-                ProgressView("Loading...")
-            } else {
-                List(viewModel.movies, id: \.title) { movie in
-                    Text(movie.title)
+            VStack {
+                if viewModel.isLoading {
+                    ProgressView("Loading...")
+                } else {
+                    List(viewModel.movies, id: \.title) { movie in
+                        Text(movie.title)
+                    }
                 }
             }
         }
         .padding(.top)
+        .alert(isPresented: $viewModel.showErrorAlert) {  // Alert
+            Alert(title: Text("An Error Occurred"),
+                  message: Text(viewModel.error?.localizedDescription ?? "Unknown error"),
+                  dismissButton: .default(Text("OK")))
+        }
     }
 }
+
 
 struct SearchView_Preview: PreviewProvider {
     static var previews: some View {


### PR DESCRIPTION
Now there's an alert that pops up

<img width="346" alt="image" src="https://github.com/ChopperTheKing/CineSightApp/assets/56698317/61933a46-530b-4f2a-b009-23cfc76a6e62">
